### PR TITLE
specify argument to emoji_get

### DIFF
--- a/R/geom_emoji.R
+++ b/R/geom_emoji.R
@@ -105,7 +105,7 @@ geom_emoji <- function(mapping = NULL, data = NULL, stat = "identity",
   # get the emojipar
   emojipar <- eval(substitute(alist(...)))
   # download the emoji in advance!
-  img <- emoji_get(emojipar)[[1]]
+  img <- emoji_get(emojipar$emoji)[[1]]
 
   layer(
     data = data,


### PR DESCRIPTION
Using the "size" argument of geom_emoji caused an error. I suspect that the reason was that it was accidentally passed to emoji_get in that line:
``` R
# emojipar contains all additional arguments to geom_emoji
img <- emoji_get(emojipar)[[1]]
```
A quick fix is to explicitly specify `emojipar$emoji` in the call to emoji_get. It seems to work well for me.

I don't know whether it might cause issues elsewhere, however, so feel free to ignore if this is actually a bad idea.