### PR TITLE
Update geom_emoji.R

### DIFF
--- a/R/geom_emoji.R
+++ b/R/geom_emoji.R
@@ -107,7 +107,7 @@ geom_emoji <- function(mapping = NULL, data = NULL, stat = "identity",
   # download the emoji in advance!
   img <- emoji_get(emojipar$emoji)[[1]]
 
-  layer(
+  ggplot2::layer(
     data = data,
     mapping = mapping,
     stat = stat,


### PR DESCRIPTION
When importing emoGG to another package (i.e not calling `library()`), it fails with the error 'could not find function "layer"'.

This fixes this issue.