### PR TITLE
Fix emoji aspect ratio by setting explicit width and height

### DIFF
--- a/R/geom_emoji.R
+++ b/R/geom_emoji.R
@@ -2,6 +2,8 @@
 #'
 #' Use emoji as you would \code{\link{geom_point}}.
 #'
+#' The \code{size} aesthetic controls the emoji width and height in millimetres.
+#'
 #' @author David L Miller
 #' @importFrom proto proto
 #' @importFrom grid rasterGrob grobTree
@@ -18,7 +20,7 @@
 #'
 #' # plot the data, but with emojis
 #' ggplot(iris, aes(Sepal.Length, Sepal.Width, color = Species)) +
-#'   geom_emoji(emoji="1f337")
+#'   geom_emoji(emoji="1f337", size = 12)
 #'
 #'}
 geom_emoji <- function(mapping = NULL, data = NULL, stat = "emoji",

--- a/R/geom_emoji.R
+++ b/R/geom_emoji.R
@@ -63,8 +63,8 @@ emojisGrob <- function(coords){
                y             = y,
                image         = emoji,
                default.units = "native",
-               height        = size,
-               width         = size)
+               height        = unit(size, "mm"),
+               width         = unit(size, "mm"))
   }
   ff <- function(coords){
     raster_it(coords$x, coords$y, coords$size, coords$emoji)

--- a/README.Rmd
+++ b/README.Rmd
@@ -41,13 +41,13 @@ The `iris` example with **real** irises (well, tulips...)
 
 ```{r iris_ex, fig.height=4, fig.width=4}
 ggplot(iris, aes(Sepal.Length, Sepal.Width, color = Species)) +
-  geom_emoji(emoji="1f337")
+  geom_emoji(emoji="1f337", size = 6)
 ```
 
 What about plotting `mtcars` with **real** cars?
 
 ```{r mtcars, fig.height=4, fig.width=4}
-ggplot(mtcars, aes(wt, mpg))+ geom_emoji(emoji="1f697")
+ggplot(mtcars, aes(wt, mpg))+ geom_emoji(emoji="1f697", size = 6)
 ```
 
 Want to map `emoji` as an aesethetic? [Check out this gist](https://gist.github.com/dill/28bb04fc35b51326f01b23d078f5021e)!
@@ -57,7 +57,7 @@ Some random cats?
 ```{r, catplotlib, fig.height=4, fig.width=4}
 posx <- runif(50, 0, 10)
 posy <- runif(50, 0, 10)
-ggplot(data.frame(x = posx, y = posy), aes(x, y)) + geom_emoji(emoji="1f63b")
+ggplot(data.frame(x = posx, y = posy), aes(x, y)) + geom_emoji(emoji="1f63b", size = 6)
 ```
 
 We can also just put a big emoji in the background:

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ look for a tulip:
 The `iris` example with **real** irises (well, tulips...)
 
     ggplot(iris, aes(Sepal.Length, Sepal.Width, color = Species)) +
-      geom_emoji(emoji="1f337")
+      geom_emoji(emoji="1f337", size = 6)
 
 ![](figure/iris_ex-1.png)
 
 What about plotting `mtcars` with **real** cars?
 
-    ggplot(mtcars, aes(wt, mpg))+ geom_emoji(emoji="1f697")
+    ggplot(mtcars, aes(wt, mpg))+ geom_emoji(emoji="1f697", size = 6)
 
 ![](figure/mtcars-1.png)
 
@@ -53,7 +53,7 @@ Some random cats?
 
     posx <- runif(50, 0, 10)
     posy <- runif(50, 0, 10)
-    ggplot(data.frame(x = posx, y = posy), aes(x, y)) + geom_emoji(emoji="1f63b")
+    ggplot(data.frame(x = posx, y = posy), aes(x, y)) + geom_emoji(emoji="1f63b", size = 6)
 
 ![](figure/catplotlib-1.png)
 

--- a/man/geom_emoji.Rd
+++ b/man/geom_emoji.Rd
@@ -17,6 +17,8 @@ geom_emoji(
 }
 \description{
 Use emoji as you would \code{\link{geom_point}}.
+
+The \code{size} aesthetic controls the emoji width and height in millimetres.
 }
 \examples{
 \dontrun{
@@ -28,7 +30,7 @@ emoji_search("tulip")
 
 # plot the data, but with emojis
 ggplot(iris, aes(Sepal.Length, Sepal.Width, color = Species)) +
-  geom_emoji(emoji="1f337")
+  geom_emoji(emoji="1f337", size = 12)
 
 }
 }


### PR DESCRIPTION
This PR fixes emoji rendering in `geom_emoji()` by explicitly setting both width and height on the underlying `rasterGrob()` using unit-based dimensions.

Previously, emoji size and aspect ratio could vary across devices and plots. By enforcing square dimensions in millimetres, emojis now render consistently.

**Trade-off**: Because emoji dimensions are now unit-based, users must specify `size` (or adjust `default_aes`) to control visible emoji size.

Documentation and examples were updated to clarify that the size aesthetic controls the emoji width and height in mm.